### PR TITLE
Set wax to inactive

### DIFF
--- a/data/projects/wax.ts
+++ b/data/projects/wax.ts
@@ -3,13 +3,11 @@ import { ProjectInterface } from "@/lib/types"
 export const wax: ProjectInterface = {
   id: "wax",
   section: "pse",
-  projectStatus: "active",
+  projectStatus: "inactive",
   image: "wax.webp",
   name: "Wallet Account eXperiments - WAX",
   links: {
     github: "https://github.com/getwax",
-    website: "https://wax.pse.dev/",
-    discord: "https://discord.gg/hGDmAhcRyz",
   },
   tags: {
     builtWith: [


### PR DESCRIPTION
The WAX project is being sunsetted. See [announcement in discord](https://discord.com/channels/943612659163602974/963404009266376774/1278031967367073964)

This PR:
* Sets the wax project from active to inactive
* Removes the website and discord urls as both of those resources will be being spun down

Let me know if I need to do anything else. I left logo and locales as they were