### PR TITLE
Update nav hrefs, fix footer navigation 

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -43,7 +43,7 @@ export function MainNav({ items, lang = fallbackLng }: MainNavProps) {
           return (
             <Link
               key={index}
-              href={!item?.external ? `/${lang}/${item.href}` : item.href}
+              href={!item?.external ? `/${lang}${item.href}` : item.href}
               target={item.external ? "_blank" : undefined}
               className={cn(
                 "flex cursor-pointer items-center border-b-2 uppercase",

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -76,7 +76,7 @@ export function SiteFooter({ lang }: LangProps["params"]) {
                   !onlyHeader && (
                     <Link
                       key={indexKey}
-                      href={href}
+                      href={external ? href : `/${lang}${href}`}
                       target={external ? "_blank" : undefined}
                     >
                       <ItemLabel label={title} />

--- a/components/site-header-mobile.tsx
+++ b/components/site-header-mobile.tsx
@@ -113,7 +113,7 @@ export function SiteHeaderMobile({ lang }: LangProps["params"]) {
               return (
                 <NextLink
                   key={index}
-                  href={item?.external ? item.href : `/${lang}/${item.href}`}
+                  href={item?.external ? item.href : `/${lang}${item.href}`}
                   onClick={() => setHeader(false)}
                   className="border-b-2 border-white p-4 uppercase"
                 >


### PR DESCRIPTION
This PR fixes #238 by updating Header, Mobile Header and Footer components to use the `/[lang]/[path]` format for all relevant href values. 

Previously, Header and Mobile header links were pointing to `/[lang]//[path]` (extra slash).

Footer links were just `/[path]`, which was causing an Error on the Devcon 7 page.