### PR TITLE
Mark trusted setup projects as inactive

### DIFF
--- a/data/projects/p0tion.ts
+++ b/data/projects/p0tion.ts
@@ -8,14 +8,24 @@ import {
 const content: ProjectContent = {
   en: {
     tldr: "Toolkit for Groth16 Phase 2 Trusted Setup ceremonies.",
-    description: `p0tion is an agnostic-from-ceremony public good toolkit, with the aim of making Groth16 zk-applications scale and become production-ready in a safe and secure manner by running Phase 2 Trusted Setup ceremonies.`,
+    description: `### Overview
+    p0tion is an agnostic-from-ceremony public good toolkit, with the aim of making Groth16 zk-applications scale and become production-ready in a safe and secure manner by running Phase 2 Trusted Setup ceremonies.
+
+    ### Status
+    This project has been sunset and it is entering to a long term support phase (no further development). p0tion toolkit is availabe for developers to use and run their own trusted setups ceremonies. We encourage the community to fork and continue the improvement of this toolkit.
+
+    ### Resources
+
+    - **p0tion**: A tool to help developers create and manage trusted setups - [GitHub](https://github.com/privacy-scaling-explorations/p0tion)
+    - **DefinitelySetup WebApp**: A WebApp to monitor and contribute to trusted setups - [Website](https://ceremony.pse.dev/) | [GitHub](https://github.com/privacy-scaling-explorations/DefinitelySetup)
+    `,
   },
 }
 
 export const p0tion: ProjectInterface = {
   id: "p0tion",
   category: ProjectCategory.DEVTOOLS,
-  projectStatus: ProjectStatus.ACTIVE,
+  projectStatus: ProjectStatus.INACTIVE,
   section: "pse",
   content,
   image: "p0tion.png",

--- a/data/projects/p0tion.ts
+++ b/data/projects/p0tion.ts
@@ -26,7 +26,7 @@ export const p0tion: ProjectInterface = {
   id: "p0tion",
   category: ProjectCategory.DEVTOOLS,
   projectStatus: ProjectStatus.INACTIVE,
-  section: "pse",
+  section: "archived",
   content,
   image: "p0tion.png",
   name: "p0tion",

--- a/data/projects/powers-of-tau.ts
+++ b/data/projects/powers-of-tau.ts
@@ -24,7 +24,7 @@ export const PerpetualPowersOfTau: ProjectInterface = {
   image: "powers-of-tau.png",
   name: "Perpetual Powers of Tau",
   projectStatus: ProjectStatus.INACTIVE,
-  section: "pse",
+  section: "archived",
   content,
   tags: {
     keywords: ["scaling"],

--- a/data/projects/powers-of-tau.ts
+++ b/data/projects/powers-of-tau.ts
@@ -8,7 +8,13 @@ import {
 const content: ProjectContent = {
   en: {
     tldr: "An ongoing (since 2019) zk-SNARK trusted setup ceremony for circuits up to 2^28 constraints.",
-    description: `The Perpetual Powers of Tau is a multi-party trusted setup ceremony, rooted in the Zcash Powers of Tau. Its primary objective is the secure generation of zk-SNARK parameters for circuits accommodating up to 2^28 (260+ million) constraints. This translates to the creation of over 530 million powers of tau. The ceremony's integrity hinges on the principle that as long as one participant acts honestly and remains uncompromised, the entire setup remains trustworthy. It's a pivotal step for zk-SNARK projects, ensuring the security and privacy of the system. Those who can handle a 100Gb download and many hours of compute time are invited to join by contacting [@glamperd on Twitter](https://twitter.com/glamperd) or Telegram, or asking questions via the PSE [Discord](https://discord.com/invite/sF5CT5rzrR).`,
+    description: `### Overview
+
+    The Perpetual Powers of Tau is a multi-party trusted setup ceremony, rooted in the Zcash Powers of Tau. Its primary objective is the secure generation of zk-SNARK parameters for circuits accommodating up to 2^28 (260+ million) constraints. This translates to the creation of over 530 million powers of tau. The ceremony's integrity hinges on the principle that as long as one participant acts honestly and remains uncompromised, the entire setup remains trustworthy. It's a pivotal step for zk-SNARK projects, ensuring the security and privacy of the system. Those who can handle a 100Gb download and many hours of compute time are invited to join by contacting [@nicoserranop on Twitter](https://twitter.com/NicoSerranoP) or Telegram, or asking questions via the PSE [Discord](https://discord.com/invite/sF5CT5rzrR).
+
+    ### Status
+    This project is entering a long term support phase. The ceremony is ongoing and accepting new participants. There are no further development plans for the project.
+    `,
   },
 }
 
@@ -17,7 +23,7 @@ export const PerpetualPowersOfTau: ProjectInterface = {
   category: ProjectCategory.DEVTOOLS,
   image: "powers-of-tau.png",
   name: "Perpetual Powers of Tau",
-  projectStatus: ProjectStatus.ACTIVE,
+  projectStatus: ProjectStatus.INACTIVE,
   section: "pse",
   content,
   tags: {

--- a/data/projects/trusted-setups.ts
+++ b/data/projects/trusted-setups.ts
@@ -8,14 +8,26 @@ import {
 const content: ProjectContent = {
   en: {
     tldr: "Aiding developers with tools for trusted setups.",
-    description: `The Trusted Setups project is dedicated to simplifying the process of trusted setups, which are crucial for privacy or scaling solutions. Trusted setups involve multiple participants contributing to the generation of secrets. As long as one participant forgets their part of the secret, the final solution remains secure. The team recognizes the complexity of developing contribution programs and coordinating the participants' queue in a trusted setup. To address this, they are developing tools, including scripts, WebApps, and APIs, to streamline the contribution and coordination effort. This allows developers to focus on building their circuits and applications, enhancing efficiency and productivity in the development of zero-knowledge applications.`,
+    description: `### Overview
+    The Trusted Setups project is dedicated to simplifying the process of trusted setups, which are crucial for privacy or scaling solutions. Trusted setups involve multiple participants contributing to the generation of secrets. As long as one participant forgets their part of the secret, the final solution remains secure. The team recognizes the complexity of developing contribution programs and coordinating the participants' queue in a trusted setup. To address this, they are developing tools, including scripts, WebApps, and APIs, to streamline the contribution and coordination effort. This allows developers to focus on building their circuits and applications, enhancing efficiency and productivity in the development of zero-knowledge applications.
+
+    ### Status
+    This project has been sunset and there will be no further development. The tools and resources developed are available under no warranty and are provided as-is. We believe they are enough for developers to run their trusted setups on their own. The team encourages the community to fork and continue the development of these tools.
+
+    ### Resources
+
+    - **p0tion**: A tool to help developers create and manage trusted setups - [GitHub](https://github.com/privacy-scaling-explorations/p0tion)
+    - **DefinitelySetup WebApp**: A WebApp to monitor and contribute to trusted setups - [Website](https://ceremony.pse.dev/) | [GitHub](https://github.com/privacy-scaling-explorations/DefinitelySetup)
+    - **KZG WebApp**: A WebApp used to contributed to the KZG Ceremony - [Website](https://ceremony.ethereum.org/) | [GitHub](https://github.com/zkparty/trusted-setup-frontend)
+    - **Perpetual Powers of Tau**: A phase 1 ceremony to generate Powers of Tau - [GitHub](https://github.com/privacy-scaling-explorations/perpetualpowersoftau)
+    `,
   },
 }
 
 export const trustedSetups: ProjectInterface = {
   id: "trusted-setups",
   category: ProjectCategory.DEVTOOLS,
-  projectStatus: ProjectStatus.ACTIVE,
+  projectStatus: ProjectStatus.INACTIVE,
   section: "pse",
   content,
   image: "trusted-setups.svg",

--- a/data/projects/trusted-setups.ts
+++ b/data/projects/trusted-setups.ts
@@ -28,7 +28,7 @@ export const trustedSetups: ProjectInterface = {
   id: "trusted-setups",
   category: ProjectCategory.DEVTOOLS,
   projectStatus: ProjectStatus.INACTIVE,
-  section: "pse",
+  section: "archived",
   content,
   image: "trusted-setups.svg",
   name: "Trusted Setups",


### PR DESCRIPTION
We are sunsetting the Trusted Setups team and I have added a couple of descriptions in the PSE website. The following projects have been updated: 

- p0tion
- Perpetual Powers of Tau
- Trusted Setups


@sripwoud could you please take a look at the STATUS description and confirm if everything is correct? 😊 