### PR TITLE
Fixed broken 'Edit this page' links in the project library

### DIFF
--- a/data/projects/mpc.ts
+++ b/data/projects/mpc.ts
@@ -25,7 +25,7 @@ You can find the detail of the protocol [here](https://eprint.iacr.org/2024/264)
 }
 
 export const mpc: ProjectInterface = {
-  id: "MPC",
+  id: "mpc",
   category: ProjectCategory.RESEARCH,
   projectStatus: ProjectStatus.ACTIVE,
   section: "pse",

--- a/data/projects/powers-of-tau.ts
+++ b/data/projects/powers-of-tau.ts
@@ -13,7 +13,7 @@ const content: ProjectContent = {
 }
 
 export const PerpetualPowersOfTau: ProjectInterface = {
-  id: "perpetual-powers-of-tau",
+  id: "powers-of-tau",
   category: ProjectCategory.DEVTOOLS,
   image: "powers-of-tau.png",
   name: "Perpetual Powers of Tau",


### PR DESCRIPTION
  The url link of 'Edit this page' is generated with the 'id'