### PR TITLE
fix: typo in documentation file

### DIFF
--- a/articles/zkopru-trusted-setup-ceremony.md
+++ b/articles/zkopru-trusted-setup-ceremony.md
@@ -56,7 +56,7 @@ Click Launch Ceremony
 
 Wait until you see this
 
-## Troubeshooting
+## Troubleshooting
 
 If the twitter button doesnt show up in your browser you can try this: Refresh > Menu >Logout, then Login, and launch again. It won’t run any circuits, but it might pick up your hashes and allow you to tweet.
 


### PR DESCRIPTION


Description: 
Corrected "Troubeshooting" → "Troubleshooting"