### PR TITLE
docs(sonobe): fix broken website link

### DIFF
--- a/content/projects/sonobe.md
+++ b/content/projects/sonobe.md
@@ -13,7 +13,7 @@ tags:
   builtWith: ["rust"]
 links:
   github: "https://github.com/privacy-scaling-explorations/sonobe"
-  website: "https://privacy-scaling-explorations.github.io/sonobe-docs"
+  website: "https://sonobe.pse.dev/"
 ---
 
 In collaboration with [0xPARC](https://0xparc.org), [Sonobe](https://github.com/privacy-scaling-explorations/sonobe) is a modular library to fold arithmetic circuit instances in an Incremental Verifiable computation (IVC) style. It supports multiple frontends, multiple folding schemes, and multiple decider backends, allowing users to plug-and-play different components.


### PR DESCRIPTION
https://privacy-scaling-explorations.github.io/sonobe-docs - broken
https://sonobe.pse.dev/ - correct
