### PR TITLE
docs: update Private Reads masterplan

### DIFF
--- a/app/(pages)/mastermap/[projectId]/page.tsx
+++ b/app/(pages)/mastermap/[projectId]/page.tsx
@@ -133,7 +133,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
                       className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
                     >
                       <span className="text-anakiwa-500 shrink-0">&#10003;</span>
-                      {renderLinks(item)}
+                      <span>{renderLinks(item)}</span>
                     </li>
                   ))}
                 </ul>
@@ -150,7 +150,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
                     className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
                   >
                     <span className="text-anakiwa-500 shrink-0">&#10003;</span>
-                    {renderLinks(item)}
+                    <span>{renderLinks(item)}</span>
                   </li>
                 ))}
               </ul>
@@ -166,7 +166,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
                     className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
                   >
                     <span className="text-anakiwa-500 shrink-0">&#10003;</span>
-                    {renderLinks(item)}
+                    <span>{renderLinks(item)}</span>
                   </li>
                 ))}
               </ul>

--- a/app/(pages)/mastermap/[projectId]/page.tsx
+++ b/app/(pages)/mastermap/[projectId]/page.tsx
@@ -6,6 +6,7 @@ import { NowNextLater } from "@/components/mastermap/now-next-later"
 import { ProgressBar } from "@/components/mastermap/progress-bar"
 import { StatusBadge } from "@/components/mastermap/status-badge"
 import { PROJECTS, CATEGORIES } from "@/components/mastermap/mastermap-data"
+import { renderLinks } from "@/components/mastermap/render-links"
 import type { Metadata } from "next"
 
 interface PageProps {
@@ -53,7 +54,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
             {project.name}
           </h1>
           <p className="text-base lg:text-lg text-tuatara-500 dark:text-tuatara-300 font-sans max-w-2xl leading-relaxed">
-            {project.description}
+            {renderLinks(project.description)}
           </p>
           {project.projectUrl && (
             <AppLink
@@ -113,23 +114,31 @@ export default async function ProjectDetailPage({ params }: PageProps) {
       {/* Details Grid */}
       {project.details && (
         <AppContent>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div>
-              <h3 className="font-sans text-base font-bold text-tuatara-950 dark:text-white mb-3">
-                Description
-              </h3>
-              <ul className="space-y-2">
-                {project.details.description.map((item, i) => (
-                  <li
-                    key={i}
-                    className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
-                  >
-                    <span className="text-anakiwa-500 shrink-0">&#10003;</span>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </div>
+          <div
+            className={`grid grid-cols-1 gap-6 ${
+              project.details.description && project.details.description.length > 0
+                ? "md:grid-cols-3"
+                : "md:grid-cols-2"
+            }`}
+          >
+            {project.details.description && project.details.description.length > 0 && (
+              <div>
+                <h3 className="font-sans text-base font-bold text-tuatara-950 dark:text-white mb-3">
+                  Description
+                </h3>
+                <ul className="space-y-2">
+                  {project.details.description.map((item, i) => (
+                    <li
+                      key={i}
+                      className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
+                    >
+                      <span className="text-anakiwa-500 shrink-0">&#10003;</span>
+                      {renderLinks(item)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <div>
               <h3 className="font-sans text-base font-bold text-tuatara-950 dark:text-white mb-3">
                 Deliverables
@@ -141,7 +150,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
                     className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
                   >
                     <span className="text-anakiwa-500 shrink-0">&#10003;</span>
-                    {item}
+                    {renderLinks(item)}
                   </li>
                 ))}
               </ul>
@@ -157,7 +166,7 @@ export default async function ProjectDetailPage({ params }: PageProps) {
                     className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 flex gap-2"
                   >
                     <span className="text-anakiwa-500 shrink-0">&#10003;</span>
-                    {item}
+                    {renderLinks(item)}
                   </li>
                 ))}
               </ul>

--- a/app/(pages)/mastermap/page.tsx
+++ b/app/(pages)/mastermap/page.tsx
@@ -2,6 +2,7 @@ import { LABELS } from "@/app/labels"
 import { AppContent } from "@/components/ui/app-content"
 import { ProjectCard } from "@/components/mastermap/project-card"
 import { CATEGORIES, PROJECTS } from "@/components/mastermap/mastermap-data"
+import { renderLinks } from "@/components/mastermap/render-links"
 import { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -55,7 +56,7 @@ export default function MasterMapPage() {
                 )}
               </h2>
               <p className="text-sm lg:text-base text-tuatara-500 dark:text-tuatara-300 font-sans mt-1">
-                {category.description}
+                {renderLinks(category.description)}
               </p>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">

--- a/app/(pages)/mastermap/page.tsx
+++ b/app/(pages)/mastermap/page.tsx
@@ -41,7 +41,18 @@ export default function MasterMapPage() {
           <AppContent key={category.id} className="flex flex-col gap-5">
             <div>
               <h2 className="text-xl lg:text-2xl font-bold font-display text-tuatara-950 dark:text-white">
-                {category.name}
+                {category.url ? (
+                  <a
+                    href={category.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-anakiwa-500 transition-colors"
+                  >
+                    {category.name}
+                  </a>
+                ) : (
+                  category.name
+                )}
               </h2>
               <p className="text-sm lg:text-base text-tuatara-500 dark:text-tuatara-300 font-sans mt-1">
                 {category.description}

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -740,13 +740,6 @@ export const PROJECTS: ProjectData[] = [
         statusDot: "green",
       },
       {
-        name: "VIA in Rust",
-        description:
-          "Port VIA from [Pythonic specs](https://github.com/turanzv/via-spec) to a Rust reference implementation; feeds into the sharded harness and benchmark comparisons.",
-        status: "Q2 2026",
-        statusDot: "green",
-      },
-      {
         name: "Balance-retrieval demo",
         description:
           "End-to-end demo of ETH balance retrieval over LeanPIR, targeted at wallet integration.",
@@ -763,24 +756,24 @@ export const PROJECTS: ProjectData[] = [
     ],
     next: [
       {
-        name: "LeanPIR paper",
+        name: "VIA in Rust",
         description:
-          "Academic paper on LeanPIR and its GPU acceleration. EuroTT workshop keynote targeted for May 2026.",
+          "Port VIA from [Pythonic specs](https://github.com/turanzv/via-spec) to a Rust reference implementation; feeds into the sharded harness and benchmark comparisons.",
         status: "Q2 2026",
         statusDot: "yellow",
       },
       {
-        name: "GPU multi-collaborator scale-up",
+        name: "LeanPIR paper",
         description:
-          "Multi-GPU (100+ GB scale) collaboration with external researchers (Seoul National University, Illinois) — microgrants and co-authorship.",
-        status: "Q2–Q3 2026",
+          "Academic paper on LeanPIR and its GPU acceleration. EuroTT workshop keynote targeted for May 2026.",
+        status: "Q2-3 2026",
         statusDot: "yellow",
       },
       {
-        name: "PIR integration in wallet / light client",
+        name: "GPU scale-up",
         description:
-          "Ad-hoc LeanPIR demo integrated into a wallet and/or light client.",
-        status: "Q3 2026 · Critical",
+          "Benchmark the leading candidates for GPU-accelerated PIR — Inspire, Onion v2, LeanPIR, VIA, and Harmony — at 100+ GB scale. Benchmark matrix being db/entry sizes, db segmentation, no. GPUs, ..",
+        status: "Q2–Q3 2026",
         statusDot: "yellow",
       },
     ],

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -65,7 +65,7 @@ export const CATEGORIES: Category[] = [
     id: "private-reads",
     name: "Private Reads",
     description:
-      "Protect Ethereum users from leaking _who_ they are and _what_ they are reading from the Ethereum blockchain.",
+      "Protect Ethereum users from leaking [who](https://privreads.ethereum.foundation/workstreams/torjs) they are and [what](https://privreads.ethereum.foundation/workstreams/pir) they are reading from the Ethereum [state](https://privreads.ethereum.foundation/workstreams/ubt/).",
     color: "#50C3E0",
     bgLight: "bg-anakiwa-50",
     bgDark: "dark:bg-anakiwa-975/30",

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -1039,16 +1039,16 @@ export const PROJECTS: ProjectData[] = [
     ],
     later: [
       {
-        name: "PIR-over-Tor bootstrap",
+        name: "Direct Edge to P2P boradcasting+",
         description:
-          "Use our own PIR to privately retrieve the Tor directory on bootstrap, removing a plaintext metadata leak at the start of every session.",
+          "Support edge (wallets, light clients, ..) to P2P transaction broadcasting and IP-leakage prevention, leveraging WebRTC work in TorJS plus (a) .onion-exposing infra providers (dRPC, Flashbots, …) and (b) direct ethp2p peers after that [abstraction is implemented](/mastermap/access-layer).",
         status: "Q3 2026",
         statusDot: "gray",
       },
       {
-        name: "Wallet P2P tx broadcasting / IP-leakage prevention",
+        name: "PIR-over-Tor bootstrap",
         description:
-          "Support wallets on optional P2P transaction broadcasting and IP-leakage prevention, leveraging WebRTC plus .onion-exposing infra providers (dRPC, Flashbots, …).",
+          "Use our own PIR to privately retrieve the Tor directory on bootstrap, removing a plaintext metadata leak at the start of every session.",
         status: "Q3 2026",
         statusDot: "gray",
       },

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -886,6 +886,7 @@ export const PROJECTS: ProjectData[] = [
         "WebRTC transport PoC across TorJS and Geth",
       ],
       impact: [
+        "Make Ethereum users' assumed-ISP-exposed web2 traffic unlinkable to transacting on or reading the Ethereum state — via any anonymization network they choose",
         "Apps are not bound to a single anonymization network; users and integrators can choose",
         "Ethereum RPC traffic becomes routable over any anonym. network (onion, mixnet, or any other)",
         "Censorship and centralized RPC outages no longer take wallets offline",
@@ -1058,11 +1059,12 @@ export const PROJECTS: ProjectData[] = [
     ],
     details: {
       deliverables: [
-        "WASM-compiled Arti client (shipped Q1 2026, see [privreads.ethereum.foundation/docs/torjs](https://privreads.ethereum.foundation/docs/torjs/))",
+        "WASM-compiled Arti client ([shipped Q1 2026](https://privreads.ethereum.foundation/docs/torjs/))",
         "Integrations across wallets, SDKs (ethers.js, viem.js), and light clients, seeded by a Kohaku reference integration",
         "Arti security audit report and upstream merges into Tor Project's Arti",
       ],
       impact: [
+        "Make Ethereum users' assumed-ISP-exposed web2 traffic unlinkable to transacting on or reading the Ethereum state",
         "Ethereum users get network-level privacy without installing additional software",
         "RPC providers can no longer correlate queries with user IPs",
         "Any wallet, SDK, or light client that adopts the transport inherits anonymized routing",

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -833,11 +833,11 @@ export const PROJECTS: ProjectData[] = [
     id: "access-layer",
     name: "Anonymization Access Layer",
     category: "private-reads",
-    status: "Research",
-    statusVariant: "research",
+    status: "Active R&D",
+    statusVariant: "rd",
     completion: 10,
     description:
-      "Pluggable abstraction over anonymization networks (Tor, Nym, Nox, mixnets). Wallets, SDKs, and clients can swap networks without app-layer changes.",
+      "Pluggable abstraction over anonymization networks (onion nets, mixnets, or any other). The edge ([in-browser] wallets, SDKs, light-clients, ..) can swap networks without app-layer changes.",
     href: "/mastermap/access-layer",
     tags: ["Access Layer", "WebRTC", "Mixnet", "Onion routing"],
     now: [
@@ -852,13 +852,6 @@ export const PROJECTS: ProjectData[] = [
         name: "WebRTC transport kit",
         description:
           "Foundational transport for the [access layer](https://privreads.ethereum.foundation/code) — connectivity from the edge (browsers, wallets) to a range of infrastructure: PIR servers, anonymity-network nodes (Tor, mixnets), and Ethereum p2p nodes. Born from [embedding Arti in the browser](https://privreads.ethereum.foundation/feed/embedding-arti-in-the-browser), then generalized; same wire behavior across TorJS, Geth (in-process go-webrtc), other EL clients, and Rust-based mixnet nodes.",
-        status: "In progress",
-        statusDot: "green",
-      },
-      {
-        name: "Mixnet survey",
-        description:
-          "Survey of mixnet implementations (Nym, Nox, HOPR, Anyone.io, fileverse's 0) as candidate backends for the access layer.",
         status: "In progress",
         statusDot: "green",
       },
@@ -880,13 +873,6 @@ export const PROJECTS: ProjectData[] = [
       },
     ],
     later: [
-      {
-        name: "LLM privacy scrubber",
-        description:
-          "Local-LLM-backed agent that sanitizes user queries before they leave the client, paired with the access layer for network-level privacy on top.",
-        status: "Q3 2026",
-        statusDot: "gray",
-      },
       {
         name: "Lean verifiable software integration",
         description:
@@ -955,14 +941,14 @@ export const PROJECTS: ProjectData[] = [
       {
         name: "zkVM proving of UBT transitions",
         description:
-          "Recursive zkVM proof chain that UBT state updates match MPT updates per block. Pursue via microgrants once the node is sync'd.",
+          "Recursive zkVM proof chain that UBT state updates match MPT updates per block.",
         status: "Q3 2026",
         statusDot: "gray",
       },
       {
         name: "UBT↔PIR integration",
         description:
-          "PIR services lean on provable UBT state — no need to trust the serving node.",
+          "PIR servers and clients lean on provable UBT state — no need to trust the serving node.",
         status: "Contingent",
         statusDot: "blue",
       },
@@ -982,13 +968,13 @@ export const PROJECTS: ProjectData[] = [
     kpis: [
       {
         label: "Mainnet-sync'd shadow chain",
-        target: "End of Q2 2026",
+        target: "Q2 2026",
         status: "Geth + Ethrex paths in flight",
       },
       {
         label: "RPC parity",
         target: "All RPCs (incl. eth_call, debug_executionWitness)",
-        status: "isolated experimental impl worked in Geth",
+        status: "Blocked by node UBT-readiness",
       },
     ],
   },
@@ -996,20 +982,19 @@ export const PROJECTS: ProjectData[] = [
     id: "tor-js",
     name: "TorJS",
     category: "private-reads",
-    status: "Active development",
-    statusVariant: "active",
+    status: "Production",
+    statusVariant: "production",
     completion: 50,
     description:
-      "[Arti](https://privreads.ethereum.foundation/feed/embedding-arti-in-the-browser) — Tor's official Rust client — compiled to WebAssembly. Anonymized RPC from wallets, frontends, and dApps, running entirely in the browser. Q1 2026 milestone: full in-browser compile shipped.",
+      "[Arti](https://privreads.ethereum.foundation/feed/embedding-arti-in-the-browser) — Tor's official Rust client — compiled to WebAssembly. Anonymized RPC from wallets, frontends, and dApps, running entirely in the browser.",
     href: "/mastermap/tor-js",
-    projectUrl: "/projects/tor-js",
     tags: ["Arti", "Anonymized RPC", "Onion routing"],
     now: [
       {
         name: "Wallet / SDK / light-client integrations",
         description:
           "Ship Arti-backed RPC routing as a general transport for wallets, SDKs (ethers.js, viem.js), and light clients — wallet-agnostic, not tied to any single client. Kohaku is the Q2 reference integration.",
-        status: "Q2 2026 · Critical",
+        status: "In progress",
         statusDot: "green",
       },
       {
@@ -1024,6 +1009,13 @@ export const PROJECTS: ProjectData[] = [
         description:
           "Browser-native WebRTC transport replacing WebSocket for Arti↔relay. In building it we saw a larger opportunity: a general-purpose transport for reaching anonymity and p2p networks from the edge (browsers, wallets). That broader effort is now the Anonymization Access Layer, with WebRTC as the core.",
         status: "In progress",
+        statusDot: "green",
+      },
+      {
+        name: "Internal Audit with LLM swarm",
+        description:
+          "Internal audit of the WASM-compiled Arti client using an LLM-based review swarm; ahead of external audit (includes dedicated audit for RustCrypto lib).",
+        status: "Q2 2026",
         statusDot: "green",
       },
     ],

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -721,9 +721,8 @@ export const PROJECTS: ProjectData[] = [
     statusVariant: "rd",
     completion: 35,
     description:
-      "[PIR schemes](https://privreads.ethereum.foundation/workstreams/pir) tailored for Ethereum state and history. Sharded multi-engine design that lets wallets, frontends, tax software, and dApps read chain data without revealing what they queried.",
+      "[PIR schemes](https://privreads.ethereum.foundation/workstreams/pir) tailored for Ethereum state and history. Sharded multi-engine design that allows Ethereum users to read chain data from remote servers without revealing what they queried.",
     href: "/mastermap/pir",
-    projectUrl: "/projects/pir-ethereum-data",
     tags: ["PIR", "Sharded PIR", "GPU", "Ethereum state"],
     now: [
       {
@@ -816,9 +815,9 @@ export const PROJECTS: ProjectData[] = [
         "ETH balance-retrieval demo over LeanPIR",
       ],
       impact: [
-        "Wallets can fetch account state without revealing what they queried",
-        "Light clients gain private state access via a common interface",
-        "Scheme-specific tradeoffs surfaced by the sharded harness",
+        "Users can fetch account state without revealing what they queried, while expressing their queries using the same Ethereum RPC standard",
+        "Developers get a unified and stable PIR interface",
+        "[Sharded](https://ethresear.ch/t/sharded-pir-design-for-the-ethereum-state/24552#p-59339-h-51-sharding-13) design and other [optimizations](https://ethresear.ch/t/sharded-pir-design-for-the-ethereum-state/24552#p-59339-h-8-ongoing-research-optimizations-18) bring PIR closer to practical overall efficiency",
       ],
     },
     kpis: [
@@ -903,7 +902,6 @@ export const PROJECTS: ProjectData[] = [
     description:
       "Provably L1-equivalent execution-layer node using a [Unified Binary Tree](https://privreads.ethereum.foundation/workstreams/ubt) ([EIP-7864](https://eips.ethereum.org/EIPS/eip-7864)). MPT-equivalent state with a zk-friendlier structure, used as a base by light clients and PIR services that need provable state transitions.",
     href: "/mastermap/ubt",
-    projectUrl: "/projects/verifiable-ubt",
     tags: ["UBT", "EIP7864", "EL Clients", "PIR"],
     now: [
       {

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -65,10 +65,11 @@ export const CATEGORIES: Category[] = [
     id: "private-reads",
     name: "Private Reads",
     description:
-      "Enable reads from Ethereum without revealing identity or intent.",
+      "Protect Ethereum users from leaking _who_ they are and _what_ they are reading from the Ethereum blockchain.",
     color: "#50C3E0",
     bgLight: "bg-anakiwa-50",
     bgDark: "dark:bg-anakiwa-975/30",
+    url: "https://privreads.ethereum.foundation",
   },
 ]
 
@@ -718,110 +719,385 @@ export const PROJECTS: ProjectData[] = [
     category: "private-reads",
     status: "Active R&D",
     statusVariant: "rd",
-    completion: 20,
+    completion: 35,
     description:
-      "PIR schemes tailored for Ethereum state and history. Optimized for wallets, frontends, tax software, dApps.",
+      "[PIR schemes](https://privreads.ethereum.foundation/workstreams/pir) tailored for Ethereum state and history. Sharded multi-engine design that lets wallets, frontends, tax software, and dApps read chain data without revealing what they queried.",
     href: "/mastermap/pir",
-    tags: ["PIR", "Private state"],
+    projectUrl: "/projects/pir-ethereum-data",
+    tags: ["PIR", "Sharded PIR", "GPU", "Ethereum state"],
     now: [
       {
-        name: "PIR Systems (2-4 schemes)",
+        name: "LeanPIR (GPU-accelerated)",
         description:
-          "PIR schemes tailored for Ethereum state and history. Optimized for wallets, frontends, tax software, dApps.",
-        status: "In progress \u00b7 Critical",
+          "[New scheme](https://privreads.ethereum.foundation/feed/update-march-2026). Sub-second preprocessing on a 32 GB database and ~30 ms response time. Productionizing with GPU acceleration via external collaborators.",
+        status: "Q2 2026 · Critical",
+        statusDot: "green",
+      },
+      {
+        name: "Sharded PIR design",
+        description:
+          "Flesh out the multi-engine sharded architecture with ≥2 inaugural schemes; builds on our [sharded PIR design](https://privreads.ethereum.foundation/feed/sharded-pir-design) for Ethereum state.",
+        status: "Q2 2026",
+        statusDot: "green",
+      },
+      {
+        name: "VIA in Rust",
+        description:
+          "Port VIA from [Pythonic specs](https://github.com/turanzv/via-spec) to a Rust reference implementation; feeds into the sharded harness and benchmark comparisons.",
+        status: "Q2 2026",
+        statusDot: "green",
+      },
+      {
+        name: "Balance-retrieval demo",
+        description:
+          "End-to-end demo of ETH balance retrieval over LeanPIR, targeted at wallet integration.",
+        status: "Q2 2026",
+        statusDot: "green",
+      },
+      {
+        name: "Reproducible benchmarks",
+        description:
+          "[Reproducible harness](https://privreads.ethereum.foundation/docs/pir-benchmarks/) comparing PIR schemes via a mix of reported data, independent replication, and benchmarking under unified test vectors.",
+        status: "Ongoing",
         statusDot: "green",
       },
     ],
     next: [
       {
-        name: "PIR Integration",
-        description: "\u22651 integration with wallet and/or light client.",
-        status: "Planned",
-        statusDot: "yellow",
-      },
-    ],
-    later: [],
-  },
-  {
-    id: "ubt",
-    name: "UBT",
-    category: "private-reads",
-    status: "Active R&D",
-    statusVariant: "rd",
-    completion: 15,
-    description:
-      "Provably L1-equivalent EL node using UBT data structure. MPT-equivalent.",
-    href: "/mastermap/ubt",
-    tags: ["UBT", "EIP7864", "Execution layer"],
-    now: [
-      {
-        name: "UBT Node (EIP7864)",
+        name: "LeanPIR paper",
         description:
-          "Provably L1-equivalent EL node using UBT data structure. MPT-equivalent.",
-        status: "In progress",
-        statusDot: "green",
-      },
-    ],
-    next: [],
-    later: [],
-  },
-  {
-    id: "tor-js",
-    name: "tor-js",
-    category: "private-reads",
-    status: "Active R&D",
-    statusVariant: "rd",
-    completion: 20,
-    description:
-      "Arti Tor client in-browser for anonymized RPC. Kohaku integration for plug-in anonymous routing in wallets and frontends.",
-    href: "/mastermap/tor-js",
-    projectUrl: "/projects/tor-js",
-    tags: ["Arti", "Tor", "Kohaku"],
-    now: [
-      {
-        name: "Arti in-browser",
-        description:
-          "Tor client running in browser for anonymized RPC calls from wallets and frontends.",
-        status: "In progress",
-        statusDot: "green",
-      },
-      {
-        name: "Kohaku Integration",
-        description:
-          "Integrate Arti with Kohaku and at least one wallet SDK for plug-in anonymous routing.",
-        status: "In progress",
-        statusDot: "green",
-      },
-    ],
-    next: [
-      {
-        name: "Privacy Dashboard",
-        description:
-          "Showcase privacy affordances and adoption of anonymized routing in wallets and RPC providers.",
-        status: "Planned",
+          "Academic paper on LeanPIR and its GPU acceleration. EuroTT workshop keynote targeted for May 2026.",
+        status: "Q2 2026",
         statusDot: "yellow",
       },
       {
-        name: "Spotlight Series",
-        description: "2-5 articles communicating privacy to the public.",
-        status: "Planned",
+        name: "GPU multi-collaborator scale-up",
+        description:
+          "Multi-GPU (100+ GB scale) collaboration with external researchers (Seoul National University, Illinois) — microgrants and co-authorship.",
+        status: "Q2–Q3 2026",
+        statusDot: "yellow",
+      },
+      {
+        name: "PIR integration in wallet / light client",
+        description:
+          "Ad-hoc LeanPIR demo integrated into a wallet and/or light client.",
+        status: "Q3 2026 · Critical",
         statusDot: "yellow",
       },
     ],
     later: [
       {
-        name: "Certification Badges",
+        name: "[E2E](https://ethresear.ch/t/sharded-pir-design-for-the-ethereum-state/24552#p-59339-h-7-universal-pir-interface-17) sharded PIR on Ethereum state",
         description:
-          "Standardize certification badges of privacy adherence for wallets, frontends, RPC providers.",
-        status: "Q2 2026",
+          "End-to-end sharded PIR with ≥2 schemes over a non-trivial amount of Ethereum state data. Stretch carried from Q2.",
+        status: "H2 2026",
         statusDot: "gray",
       },
       {
-        name: "Wallet SDK Privacy",
+        name: "Archival-state snarkification",
         description:
-          "Drive integration of Arti for network-level-private RPC calls in wallet SDKs.",
-        status: "Q2 2026",
+          "Technical post on snarkifying archival state to reduce database size, enabling smaller PIR servers.",
+        status: "Q3 2026",
         statusDot: "gray",
+      },
+      {
+        name: "PIR ↔ Statelessness",
+        description:
+          "Exploring PIR served from Ethereum nodes and how that will work depending on the statelessness route taken by the protocol.",
+        status: "2027",
+        statusDot: "gray",
+      },
+    ],
+    details: {
+      deliverables: [
+        "Sharded PIR design fleshed out with ≥2 inaugural schemes",
+        "LeanPIR paper + GPU-accelerated reference implementation",
+        "VIA in Rust based on Pythonic specs",
+        "ETH balance-retrieval demo over LeanPIR",
+      ],
+      impact: [
+        "Wallets can fetch account state without revealing what they queried",
+        "Light clients gain private state access via a common interface",
+        "Scheme-specific tradeoffs surfaced by the sharded harness",
+      ],
+    },
+    kpis: [
+      {
+        label: "% of Ethereum state servable via PIR",
+        target: "Under practical overheads",
+        status: "Ongoing, various promising schemes for different slices",
+      },
+    ],
+  },
+  {
+    id: "access-layer",
+    name: "Anonymization Access Layer",
+    category: "private-reads",
+    status: "Research",
+    statusVariant: "research",
+    completion: 10,
+    description:
+      "Pluggable abstraction over anonymization networks (Tor, Nym, Nox, mixnets). Wallets, SDKs, and clients can swap networks without app-layer changes.",
+    href: "/mastermap/access-layer",
+    tags: ["Access Layer", "WebRTC", "Mixnet", "Onion routing"],
+    now: [
+      {
+        name: "Architecture sketch",
+        description:
+          "Design sketch (not implementation) for the access-layer abstraction; consulting Will (Protocol Labs, original Snowflake author) and peers on P2P + consensus-driven dialing.",
+        status: "In progress",
+        statusDot: "green",
+      },
+      {
+        name: "WebRTC transport kit",
+        description:
+          "Foundational transport for the [access layer](https://privreads.ethereum.foundation/code) — connectivity from the edge (browsers, wallets) to a range of infrastructure: PIR servers, anonymity-network nodes (Tor, mixnets), and Ethereum p2p nodes. Born from [embedding Arti in the browser](https://privreads.ethereum.foundation/feed/embedding-arti-in-the-browser), then generalized; same wire behavior across TorJS, Geth (in-process go-webrtc), other EL clients, and Rust-based mixnet nodes.",
+        status: "In progress",
+        statusDot: "green",
+      },
+      {
+        name: "Mixnet survey",
+        description:
+          "Survey of mixnet implementations (Nym, Nox, HOPR, Anyone.io, fileverse's 0) as candidate backends for the access layer.",
+        status: "In progress",
+        statusDot: "green",
+      },
+    ],
+    next: [
+      {
+        name: "Publish design sketch",
+        description:
+          "Publish the access-layer architecture sketch, with a companion community post inviting feedback. Share at an engineering monthly to convene wallets, SDKs, and anonymization-network maintainers around a common interface.",
+        status: "Q2 2026",
+        statusDot: "yellow",
+      },
+      {
+        name: "Reference transport spec",
+        description:
+          "Unified WebRTC transport spec usable identically from browser (WebRTC API) and Node.js (go-webrtc), with standardized WASM-binary validation across networks.",
+        status: "Q2 2026",
+        statusDot: "yellow",
+      },
+    ],
+    later: [
+      {
+        name: "LLM privacy scrubber",
+        description:
+          "Local-LLM-backed agent that sanitizes user queries before they leave the client, paired with the access layer for network-level privacy on top.",
+        status: "Q3 2026",
+        statusDot: "gray",
+      },
+      {
+        name: "Lean verifiable software integration",
+        description:
+          "Dip into Lean / formal methods for critical access-layer plumbing; early exploration of verified builds for privacy primitives.",
+        status: "Exploratory",
+        statusDot: "blue",
+      },
+    ],
+    details: {
+      deliverables: [
+        "Access-layer design sketch + community feedback",
+        "WebRTC transport PoC across TorJS and Geth",
+      ],
+      impact: [
+        "Apps are not bound to a single anonymization network; users and integrators can choose",
+        "Ethereum RPC traffic becomes routable over any anonym. network (onion, mixnet, or any other)",
+        "Censorship and centralized RPC outages no longer take wallets offline",
+      ],
+    },
+  },
+  {
+    id: "ubt",
+    name: "Verifiable UBT",
+    category: "private-reads",
+    status: "Active R&D",
+    statusVariant: "rd",
+    completion: 25,
+    description:
+      "Provably L1-equivalent execution-layer node using a [Unified Binary Tree](https://privreads.ethereum.foundation/workstreams/ubt) ([EIP-7864](https://eips.ethereum.org/EIPS/eip-7864)). MPT-equivalent state with a zk-friendlier structure, used as a base by light clients and PIR services that need provable state transitions.",
+    href: "/mastermap/ubt",
+    projectUrl: "/projects/verifiable-ubt",
+    tags: ["UBT", "EIP7864", "EL Clients", "PIR"],
+    now: [
+      {
+        name: "UBT sidecar on Geth",
+        description:
+          "Geth-based UBT node syncing mainnet. Most RPCs implemented; eth_call and debug_executionWitness pending. Blocked on inefficient binary-MPT conversion — upstream optimization work ongoing.",
+        status: "In progress · Carried from Q1",
+        statusDot: "green",
+      },
+      {
+        name: "UBT on Ethrex",
+        description:
+          "Rust EL client path, kicked off late Q1 via Lambdaclass PR. Preferred long-term for its Rust toolchain and zkVM-proving story.",
+        status: "In progress",
+        statusDot: "green",
+      },
+    ],
+    next: [
+      {
+        name: "Shadow chain sync to mainnet",
+        description:
+          "UBT shadow chain fully sync'd to mainnet head, producing MPT-equivalent state roots per block — validates the conversion pipeline under real load.",
+        status: "Q2 2026 · Critical",
+        statusDot: "yellow",
+      },
+      {
+        name: "Remaining RPC parity",
+        description:
+          "Implement eth_call and debug_executionWitness parity with MPT-backed Geth so UBT can back a full-featured node.",
+        status: "Q2 2026",
+        statusDot: "yellow",
+      },
+    ],
+    later: [
+      {
+        name: "zkVM proving of UBT transitions",
+        description:
+          "Recursive zkVM proof chain that UBT state updates match MPT updates per block. Pursue via microgrants once the node is sync'd.",
+        status: "Q3 2026",
+        statusDot: "gray",
+      },
+      {
+        name: "UBT↔PIR integration",
+        description:
+          "PIR services lean on provable UBT state — no need to trust the serving node.",
+        status: "Contingent",
+        statusDot: "blue",
+      },
+    ],
+    details: {
+      deliverables: [
+        "Fully sync'd UBT sidecar node on Geth and/or Ethrex",
+        "Recursive zkVM proof chain from genesis to head",
+        "MPT↔UBT comparison tooling",
+      ],
+      impact: [
+        "PIR services can rely on provable state without trusting a node",
+        "Light clients can verify state from genesis with a single proof chain",
+        "A concrete step toward stateless L1 execution",
+      ],
+    },
+    kpis: [
+      {
+        label: "Mainnet-sync'd shadow chain",
+        target: "End of Q2 2026",
+        status: "Geth + Ethrex paths in flight",
+      },
+      {
+        label: "RPC parity",
+        target: "All RPCs (incl. eth_call, debug_executionWitness)",
+        status: "isolated experimental impl worked in Geth",
+      },
+    ],
+  },
+  {
+    id: "tor-js",
+    name: "TorJS",
+    category: "private-reads",
+    status: "Active development",
+    statusVariant: "active",
+    completion: 50,
+    description:
+      "[Arti](https://privreads.ethereum.foundation/feed/embedding-arti-in-the-browser) — Tor's official Rust client — compiled to WebAssembly. Anonymized RPC from wallets, frontends, and dApps, running entirely in the browser. Q1 2026 milestone: full in-browser compile shipped.",
+    href: "/mastermap/tor-js",
+    projectUrl: "/projects/tor-js",
+    tags: ["Arti", "Anonymized RPC", "Onion routing"],
+    now: [
+      {
+        name: "Wallet / SDK / light-client integrations",
+        description:
+          "Ship Arti-backed RPC routing as a general transport for wallets, SDKs (ethers.js, viem.js), and light clients — wallet-agnostic, not tied to any single client. Kohaku is the Q2 reference integration.",
+        status: "Q2 2026 · Critical",
+        statusDot: "green",
+      },
+      {
+        name: "Upstream to Tor Project",
+        description:
+          "Merge async / time compatibility fixes back into Arti. WASM-readiness plumbing lands in Arti; the JS wrapper stays external.",
+        status: "In progress",
+        statusDot: "green",
+      },
+      {
+        name: "WebRTC transport for Arti",
+        description:
+          "Browser-native WebRTC transport replacing WebSocket for Arti↔relay. In building it we saw a larger opportunity: a general-purpose transport for reaching anonymity and p2p networks from the edge (browsers, wallets). That broader effort is now the Anonymization Access Layer, with WebRTC as the core.",
+        status: "In progress",
+        statusDot: "green",
+      },
+    ],
+    next: [
+      {
+        name: "Arti security audit",
+        description:
+          "External audit of the WASM-compiled Arti client before broad wallet-SDK adoption.",
+        status: "Q2 2026 · Critical",
+        statusDot: "yellow",
+      },
+      {
+        name: "Broader SDK / light-client rollout",
+        description:
+          "Land Arti-backed routing in mainstream wallet SDKs (ethers.js, viem.js) and additional light clients (Helios, etc.) for network-level-private RPC.",
+        status: "Q2 2026",
+        statusDot: "yellow",
+      },
+      {
+        name: "Messenger-protocol survey",
+        description:
+          "Survey messenger apps/protocols and propose Arti-backed anonymization integrations; pursue one reference integration.",
+        status: "Q2–Q3 2026",
+        statusDot: "yellow",
+      },
+    ],
+    later: [
+      {
+        name: "PIR-over-Tor bootstrap",
+        description:
+          "Use our own PIR to privately retrieve the Tor directory on bootstrap, removing a plaintext metadata leak at the start of every session.",
+        status: "Q3 2026",
+        statusDot: "gray",
+      },
+      {
+        name: "Wallet P2P tx broadcasting / IP-leakage prevention",
+        description:
+          "Support wallets on optional P2P transaction broadcasting and IP-leakage prevention, leveraging WebRTC plus .onion-exposing infra providers (dRPC, Flashbots, …).",
+        status: "Q3 2026",
+        statusDot: "gray",
+      },
+    ],
+    details: {
+      deliverables: [
+        "WASM-compiled Arti client (shipped Q1 2026, see [privreads.ethereum.foundation/docs/torjs](https://privreads.ethereum.foundation/docs/torjs/))",
+        "Integrations across wallets, SDKs (ethers.js, viem.js), and light clients, seeded by a Kohaku reference integration",
+        "Arti security audit report and upstream merges into Tor Project's Arti",
+      ],
+      impact: [
+        "Ethereum users get network-level privacy without installing additional software",
+        "RPC providers can no longer correlate queries with user IPs",
+        "Any wallet, SDK, or light client that adopts the transport inherits anonymized routing",
+      ],
+    },
+    kpis: [
+      {
+        label: "Integrations",
+        target: "10+ wallets/sdk's/light clients",
+        status: "Ongoing",
+      },
+      {
+        label: "Bootstrap time",
+        target: "~3 seconds",
+        status: "Achieved (was ~3 minutes)",
+      },
+      {
+        label: "Upstream Arti PRs",
+        target: "5+ landed",
+        status: "Under review with Tor Project",
+      },
+      {
+        label: "Audit",
+        target: "External audit complete",
+        status: "Internal Audit 2Q26 (LLM swarm)",
       },
     ],
   },

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -19,7 +19,7 @@ export interface ProjectData {
   later: RoadmapItem[]
   tags: string[]
   details?: {
-    description: string[]
+    description?: string[]
     deliverables: string[]
     impact: string[]
   }
@@ -39,6 +39,7 @@ export interface Category {
   color: string
   bgLight: string
   bgDark: string
+  url?: string
 }
 
 // Category colors use anakiwa (site brand) shades for consistency with the rest of the site.

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -721,7 +721,7 @@ export const PROJECTS: ProjectData[] = [
     statusVariant: "rd",
     completion: 35,
     description:
-      "[PIR schemes](https://privreads.ethereum.foundation/workstreams/pir) tailored for Ethereum state and history. Sharded multi-engine design that allows Ethereum users to read chain data from remote servers without revealing what they queried.",
+      "[PIR schemes](https://privreads.ethereum.foundation/workstreams/pir) tailored to the Ethereum hot state can and archival history, allowing users to read chain data from remote servers without revealing what is being queried. The sharded approach allows optimizing for different data types, contexts of usage, and tolerance to latency.",
     href: "/mastermap/pir",
     tags: ["PIR", "Sharded PIR", "GPU", "Ethereum state"],
     now: [
@@ -808,7 +808,8 @@ export const PROJECTS: ProjectData[] = [
         "ETH balance-retrieval demo over LeanPIR",
       ],
       impact: [
-        "Users can fetch account state without revealing what they queried, while expressing their queries using the same Ethereum RPC standard",
+        "Users can read state data without revealing what they queried while expressing their queries using the same Ethereum RPC standard",
+        "Hardening the privacy guarantees provided by other privacy measures (shielding, network-level privacy)",
         "Developers get a unified and stable PIR interface",
         "[Sharded](https://ethresear.ch/t/sharded-pir-design-for-the-ethereum-state/24552#p-59339-h-51-sharding-13) design and other [optimizations](https://ethresear.ch/t/sharded-pir-design-for-the-ethereum-state/24552#p-59339-h-8-ongoing-research-optimizations-18) bring PIR closer to practical overall efficiency",
       ],
@@ -829,9 +830,9 @@ export const PROJECTS: ProjectData[] = [
     statusVariant: "rd",
     completion: 10,
     description:
-      "Pluggable abstraction over anonymization networks (onion nets, mixnets, or any other). The edge ([in-browser] wallets, SDKs, light-clients, ..) can swap networks without app-layer changes. The architecture and access/validation standard may be extended to accessing P2P networks generally (e.g. ethp2p, which may or may not itself be participating in anonymizing RPC traffic).",
+      "Pluggable abstraction over anonymization networks (onion nets, mixnets, or any other). The edge ([in-browser] wallets, SDKs, light-clients, ..) can swap networks without app-layer changes. The architecture and access/validation standard may be extended to accessing P2P networks generally.",
     href: "/mastermap/access-layer",
-    tags: ["Access Layer", "WebRTC", "Mixnet", "Onion routing"],
+    tags: ["Access Layer", "Standards", "WebRTC", "Mixnet", "Onion routing"],
     now: [
       {
         name: "Architecture sketch",
@@ -850,9 +851,9 @@ export const PROJECTS: ProjectData[] = [
     ],
     next: [
       {
-        name: "Publish design sketch",
+        name: "Publish the arch design",
         description:
-          "Publish the access-layer architecture sketch, with a companion community post inviting feedback. Share at an engineering monthly to convene wallets, SDKs, and anonymization-network maintainers around a common interface.",
+          "Publish the access-layer architecture, with a companion community post inviting feedback. Share at an engineering monthly to convene wallets, SDKs, and anonymization-network maintainers around a common interface.",
         status: "Q2 2026",
         statusDot: "yellow",
       },
@@ -868,19 +869,19 @@ export const PROJECTS: ProjectData[] = [
       {
         name: "Lean verifiable software integration",
         description:
-          "Dip into Lean / formal methods for critical access-layer plumbing; early exploration of verified builds for privacy primitives.",
+          "Dip into Lean / formal methods for critical access-layer plumbing; early exploration of verified builds for privacy primitives, RustCrypto library being an initial candidate.",
         status: "Exploratory",
         statusDot: "blue",
       },
     ],
     details: {
       deliverables: [
-        "Access-layer design sketch + community feedback",
-        "Pilot implementation of the standard using TorJS, Tor network, Geth",
+        "Access architecture and standard + community feedback",
+        "Implement the standard and do a pilot implementation for a representative instantiation (wallet -> tor -> EL node)",
       ],
       impact: [
         "Censorship and centralized RPC outages no longer take wallets offline",
-        "Apps are not bound to a single anonymization network; users and integrators can choose",
+        "Apps are not bound to a single anonymization network; users and integrators can choose/swap",
         "Ethereum RPC traffic becomes routable over any anonym. network (onion, mixnet, or any other)",
         "Make Ethereum users' assumed-ISP-exposed web2 traffic unlinkable to transacting on or reading the Ethereum state — via any anonymization network they choose",
       ],
@@ -894,9 +895,9 @@ export const PROJECTS: ProjectData[] = [
     statusVariant: "rd",
     completion: 25,
     description:
-      "Provably L1-equivalent execution-layer node using a [Unified Binary Tree](https://privreads.ethereum.foundation/workstreams/ubt) ([EIP-7864](https://eips.ethereum.org/EIPS/eip-7864)). MPT-equivalent state with a zk-friendlier structure, used as a base by light clients and PIR services that need provable state transitions.",
+      "Provably L1-equivalent execution-layer node that is running against a [Unified Binary Tree](https://privreads.ethereum.foundation/workstreams/ubt) ([EIP-7864](https://eips.ethereum.org/EIPS/eip-7864)) PIR servers, wallets, and light clients can begin consuming binary-based state today ahead of EIP-7864 inclusion in protocol, while relying on equivalence proof for data validity.",
     href: "/mastermap/ubt",
-    tags: ["UBT", "EIP7864", "EL Clients", "PIR"],
+    tags: ["UBT", "EIP7864", "Statelessness", "EL Clients", "PIR"],
     now: [
       {
         name: "UBT sidecar on Geth",
@@ -947,14 +948,16 @@ export const PROJECTS: ProjectData[] = [
     ],
     details: {
       deliverables: [
-        "Fully sync'd UBT sidecar node on Geth and/or Ethrex",
+        "Fully sync'd UBT sidecar node on Geth / Ethrex",
         "Recursive zkVM proof chain from genesis to head",
-        "MPT↔UBT comparison tooling",
+        "MPT↔UBT utilities and monitoring tooling",
       ],
       impact: [
+        "Get the benefits of binary trie state today off-chain, and increase readiness for it when it goes on-chain (EIP-7864)",
         "PIR services can rely on provable state without trusting a node",
         "Light clients can verify state from genesis with a single proof chain",
         "A concrete step toward stateless L1 execution",
+        "Bonus: indirectly contributes to the testing and benchmarking of EIP-7864",
       ],
     },
     kpis: [
@@ -1052,8 +1055,8 @@ export const PROJECTS: ProjectData[] = [
     ],
     details: {
       deliverables: [
-        "WASM-compiled Arti client ([shipped Q1 2026](https://privreads.ethereum.foundation/docs/torjs/))",
-        "Integrations across wallets, SDKs (ethers.js, viem.js), and light clients, seeded by a Kohaku reference integration",
+        "[WASM](https://privreads.ethereum.foundation/feed/embedding-arti-in-the-browser/)-[compiled](https://privreads.ethereum.foundation/docs/torjs/) Arti client",
+        "Integrations across wallets, SDKs (ethers.js, viem.js), and light clients",
         "Arti security audit report and upstream merges into Tor Project's Arti",
       ],
       impact: [
@@ -1061,6 +1064,7 @@ export const PROJECTS: ProjectData[] = [
         "Ethereum users get network-level privacy without installing additional software",
         "RPC providers can no longer correlate queries with user IPs",
         "Any wallet, SDK, or light client that adopts the transport inherits anonymized routing",
+        "App developers can plug into onion routing using a familiar ([fetch](https://privreads.ethereum.foundation/docs/torjs/#fetch-flow)), without dealing with onionization complexity ([~3 lines of code](https://privreads.ethereum.foundation/docs/torjs))",
       ],
     },
     kpis: [

--- a/components/mastermap/mastermap-data.ts
+++ b/components/mastermap/mastermap-data.ts
@@ -830,13 +830,13 @@ export const PROJECTS: ProjectData[] = [
   },
   {
     id: "access-layer",
-    name: "Anonymization Access Layer",
+    name: "Abstract Access Layer",
     category: "private-reads",
     status: "Active R&D",
     statusVariant: "rd",
     completion: 10,
     description:
-      "Pluggable abstraction over anonymization networks (onion nets, mixnets, or any other). The edge ([in-browser] wallets, SDKs, light-clients, ..) can swap networks without app-layer changes.",
+      "Pluggable abstraction over anonymization networks (onion nets, mixnets, or any other). The edge ([in-browser] wallets, SDKs, light-clients, ..) can swap networks without app-layer changes. The architecture and access/validation standard may be extended to accessing P2P networks generally (e.g. ethp2p, which may or may not itself be participating in anonymizing RPC traffic).",
     href: "/mastermap/access-layer",
     tags: ["Access Layer", "WebRTC", "Mixnet", "Onion routing"],
     now: [
@@ -883,13 +883,13 @@ export const PROJECTS: ProjectData[] = [
     details: {
       deliverables: [
         "Access-layer design sketch + community feedback",
-        "WebRTC transport PoC across TorJS and Geth",
+        "Pilot implementation of the standard using TorJS, Tor network, Geth",
       ],
       impact: [
-        "Make Ethereum users' assumed-ISP-exposed web2 traffic unlinkable to transacting on or reading the Ethereum state — via any anonymization network they choose",
+        "Censorship and centralized RPC outages no longer take wallets offline",
         "Apps are not bound to a single anonymization network; users and integrators can choose",
         "Ethereum RPC traffic becomes routable over any anonym. network (onion, mixnet, or any other)",
-        "Censorship and centralized RPC outages no longer take wallets offline",
+        "Make Ethereum users' assumed-ISP-exposed web2 traffic unlinkable to transacting on or reading the Ethereum state — via any anonymization network they choose",
       ],
     },
   },
@@ -1006,7 +1006,7 @@ export const PROJECTS: ProjectData[] = [
       {
         name: "WebRTC transport for Arti",
         description:
-          "Browser-native WebRTC transport replacing WebSocket for Arti↔relay. In building it we saw a larger opportunity: a general-purpose transport for reaching anonymity and p2p networks from the edge (browsers, wallets). That broader effort is now the Anonymization Access Layer, with WebRTC as the core.",
+          "Browser-native WebRTC transport replacing WebSocket for Arti↔relay. In building it we saw a larger opportunity: a general-purpose transport for reaching anonymity and p2p networks from the edge (browsers, wallets). That broader effort is now the Abstract Access Layer, with WebRTC as the core.",
         status: "In progress",
         statusDot: "green",
       },

--- a/components/mastermap/now-next-later.tsx
+++ b/components/mastermap/now-next-later.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils"
 import type { RoadmapItem } from "./mastermap-data"
+import { renderLinks } from "./render-links"
 
 const STATUS_DOT_COLORS = {
   green: "bg-emerald-500",
@@ -12,10 +13,10 @@ function RoadmapItemCard({ item }: { item: RoadmapItem }) {
   return (
     <div className="pb-4 mb-4 border-b border-tuatara-100 dark:border-tuatara-700 last:border-b-0 last:mb-0 last:pb-0">
       <h4 className="font-sans text-sm font-bold text-tuatara-950 dark:text-white mb-1">
-        {item.name}
+        {renderLinks(item.name)}
       </h4>
       <p className="font-sans text-[13px] text-tuatara-500 dark:text-tuatara-300 leading-relaxed mb-1.5">
-        {item.description}
+        {renderLinks(item.description)}
       </p>
       <div className="flex items-center gap-1.5">
         <span

--- a/components/mastermap/project-card.tsx
+++ b/components/mastermap/project-card.tsx
@@ -6,7 +6,7 @@ import { ProgressBar } from "./progress-bar"
 import { StatusBadge } from "./status-badge"
 import type { ProjectData, Category } from "./mastermap-data"
 import { CATEGORIES } from "./mastermap-data"
-import { renderLinks } from "./render-links"
+import { stripLinks } from "./render-links"
 
 interface ProjectCardProps {
   project: ProjectData
@@ -49,7 +49,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
       />
 
       <p className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 leading-relaxed mb-4">
-        {renderLinks(project.description)}
+        {stripLinks(project.description)}
       </p>
 
       <div className="flex items-center justify-between">

--- a/components/mastermap/project-card.tsx
+++ b/components/mastermap/project-card.tsx
@@ -6,6 +6,7 @@ import { ProgressBar } from "./progress-bar"
 import { StatusBadge } from "./status-badge"
 import type { ProjectData, Category } from "./mastermap-data"
 import { CATEGORIES } from "./mastermap-data"
+import { renderLinks } from "./render-links"
 
 interface ProjectCardProps {
   project: ProjectData
@@ -48,7 +49,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
       />
 
       <p className="font-sans text-sm text-tuatara-500 dark:text-tuatara-300 leading-relaxed mb-4">
-        {project.description}
+        {renderLinks(project.description)}
       </p>
 
       <div className="flex items-center justify-between">

--- a/components/mastermap/render-links.tsx
+++ b/components/mastermap/render-links.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+
+const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g
+
+export function renderLinks(text: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+  LINK_RE.lastIndex = 0
+  while ((match = LINK_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index))
+    }
+    const [, label, url] = match
+    const external = /^https?:\/\//.test(url)
+    nodes.push(
+      <a
+        key={nodes.length}
+        href={url}
+        target={external ? "_blank" : undefined}
+        rel={external ? "noopener noreferrer" : undefined}
+        className="text-anakiwa-500 hover:underline"
+      >
+        {label}
+      </a>
+    )
+    lastIndex = match.index + match[0].length
+  }
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex))
+  return nodes
+}

--- a/components/mastermap/render-links.tsx
+++ b/components/mastermap/render-links.tsx
@@ -2,6 +2,10 @@ import React from "react"
 
 const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g
 
+export function stripLinks(text: string): string {
+  return text.replace(LINK_RE, "$1")
+}
+
 export function renderLinks(text: string): React.ReactNode[] {
   const nodes: React.ReactNode[] = []
   let lastIndex = 0


### PR DESCRIPTION
## Summary

Refresh the **[Private Reads](https://privreads.ethereum.foundation)** section of the masterplan (`pse.dev/mastermap`) with the current Q1 2026 retrospective and Q2 2026 forward plan. Two commits:

1. **`feat(mastermap): inline markdown links and optional category URL`** — small renderer + schema changes shared across the mastermap:
   - `renderLinks` util parses inline `[text](url)` in card content; wired through project card, project detail header, details list items, and now/next/later item names + descriptions.
   - `Category` interface gains an optional `url`; the mastermap index wraps the category heading in an anchor when `url` is set. Only Private Reads uses it today (linking to `privreads.ethereum.foundation`).
   - `details.description` becomes optional; the details grid switches to 2-col when absent.
   - **Non-Private-Reads cards render byte-for-byte unchanged** — verified no existing cards contain `[text](url)` syntax, so `renderLinks` is a pass-through everywhere else. All other cards still have `details.description`, so their details grid stays 3-col.

2. **`docs: update Private Reads masterplan`** — content-only update to the Private Reads section of `components/mastermap/mastermap-data.ts`:
   - Reorder: **PIR → Access Layer → UBT → TorJS**
   - **PIR**: fleshed out with LeanPIR, Sharded PIR design, VIA-in-Rust, balance-retrieval demo, reproducible benchmarks; collapsed KPIs to a single meaningful metric (% of Ethereum state servable via PIR).
   - **Anonymization Access Layer** (new card): promoted from the Q2 roadmap. Architecture sketch, WebRTC transport kit (foundational), mixnet survey; next steps include publishing the design sketch.
   - **Verifiable UBT**: updated with Geth sidecar + Ethrex paths, Q2 shadow-chain milestone, RPC parity plan, zkVM proving and PIR↔UBT integration as later items.
   - **TorJS**: wallet-agnostic framing (general transport for wallets, SDKs like ethers.js/viem.js, and light clients — Kohaku is the Q2 reference integration). Adds WebRTC transport item, upstream-to-Tor-Project work, Q2 audit plan.

