### PR TITLE
fix: use correct project name

### DIFF
--- a/content/articles/circuit-specific-decryption-keys-for-fhe.md
+++ b/content/articles/circuit-specific-decryption-keys-for-fhe.md
@@ -12,7 +12,7 @@ tags:
     "cryptography",
     "Machina iO",
   ]
-projects: ["machina-iO"]
+projects: ["machina-io"]
 ---
 
 # Circuit-specific decryption keys for FHE: a new four-part series from Machina iO

--- a/content/articles/unboxing-io-building-from-familar-crypto-blocks.md
+++ b/content/articles/unboxing-io-building-from-familar-crypto-blocks.md
@@ -5,7 +5,7 @@ image: "/articles/unboxing-io-building-from-familar-crypto-blocks/cover.webp"
 tldr: ""
 canonical: "https://machina-io.com/posts/unboxing.html"
 date: "2025-07-11"
-projects: ["machina-iO"]
+projects: ["machina-io"]
 ---
 
 # UNBOXING IO: BUILDING FROM FAMILIAR CRYPTO BLOCKS


### PR DESCRIPTION
## Description

Fix project reference name so it renders correctly as a project card in articles.