### PR TITLE
fix: RSS feed pubDates and exclude README (#672)

### DIFF
--- a/content/articles/post-quantum-signature-aggregation-with-falcon-and-LaBRADOR.md
+++ b/content/articles/post-quantum-signature-aggregation-with-falcon-and-LaBRADOR.md
@@ -1,6 +1,6 @@
 ---
 title: "Post-Quantum Signature Aggregation with Falcon + LaBRADOR"
-date: 2025-05-19
+date: "2025-05-19"
 author: PSE Research
 image: "/articles/post-quantum-signature-aggregation-with-falcon-and-LaBRADOR/cover.webp"
 tagline: "Compact lattice-based proofs for Ethereum"

--- a/content/articles/summon-major-update.md
+++ b/content/articles/summon-major-update.md
@@ -3,7 +3,7 @@ title: Summon Major Update
 image: "/articles/summon-major-update/cover.webp"
 tldr: I’m excited to share the biggest Summon update yet. 🎉
 authors: ["Andrew Morris"]
-date: 2025-05-21
+date: "2025-05-21"
 tags:
   [
     summon,

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -5,31 +5,30 @@ import matter from "gray-matter"
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://pse.dev"
 
-function formatDate(dateString: string | undefined): Date {
-  if (!dateString) {
-    console.warn("No date provided, using current date")
-    return new Date()
+function parseDate(rawDate: unknown): Date | null {
+  if (!rawDate) return null
+
+  // YAML auto-parses unquoted `YYYY-MM-DD` frontmatter into Date objects.
+  if (rawDate instanceof Date) {
+    return isNaN(rawDate.getTime()) ? null : rawDate
   }
 
+  if (typeof rawDate !== "string") return null
+
   try {
-    const [year, month, day] = dateString.split("-").map(Number)
+    const [year, month, day] = rawDate.split("-").map(Number)
 
     if (!year || !month || !day || isNaN(year) || isNaN(month) || isNaN(day)) {
-      console.warn(`Invalid date format: ${dateString}, using current date`)
-      return new Date()
+      return null
     }
 
     const date = new Date(year, month - 1, day)
 
-    if (isNaN(date.getTime())) {
-      console.warn(`Invalid date: ${dateString}, using current date`)
-      return new Date()
-    }
+    if (isNaN(date.getTime())) return null
 
     return date
   } catch (error) {
-    console.warn(`Error parsing date: ${dateString}, using current date`)
-    return new Date()
+    return null
   }
 }
 
@@ -59,18 +58,32 @@ export async function generateRssFeed() {
     const articlesDirectory = path.join(process.cwd(), "content/articles")
     const articleFiles = fs.readdirSync(articlesDirectory)
 
+    const excludedSlugs = new Set(["readme", "_readme", "_article-template"])
+
     const articles = articleFiles
-      .filter((file) => file.endsWith(".md") && file !== "_article-template.md")
+      .filter((file) => file.endsWith(".md"))
       .map((file) => {
+        const slug = file.replace(/\.md$/, "")
+        if (excludedSlugs.has(slug.toLowerCase())) return null
+
         try {
           const filePath = path.join(articlesDirectory, file)
           const fileContents = fs.readFileSync(filePath, "utf8")
           const { data, content } = matter(fileContents)
 
+          const pubDate = parseDate(data.date)
+          if (!pubDate) {
+            console.warn(
+              `Skipping ${file} in RSS feed: missing or invalid date`
+            )
+            return null
+          }
+
           return {
-            slug: file.replace(/\.md$/, ""),
+            slug,
             frontmatter: data,
             content,
+            pubDate,
           }
         } catch (error) {
           console.warn(`Error processing article ${file}:`, error)
@@ -80,17 +93,13 @@ export async function generateRssFeed() {
       .filter(
         (article): article is NonNullable<typeof article> => article !== null
       )
-      .sort(
-        (a, b) =>
-          formatDate(b.frontmatter.date).getTime() -
-          formatDate(a.frontmatter.date).getTime()
-      )
+      .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
 
     // Add articles to feed
     articles.forEach((article) => {
       try {
         const url = `${SITE_URL}/blog/${article.slug}`
-        const pubDate = formatDate(article.frontmatter.date)
+        const pubDate = article.pubDate
 
         feed.addItem({
           title: article.frontmatter.title || "Untitled Article",


### PR DESCRIPTION
Fixes #672.

## Summary
- The feed was stamping stale posts with build time, so they kept surfacing as "new" in aggregators on every rebuild. Root cause: YAML auto-parses unquoted `YYYY-MM-DD` frontmatter into `Date` objects, but [lib/rss.ts](lib/rss.ts)'s parser only handled strings — `.split("-")` on a `Date` failed and the code fell back to `new Date()`. Two articles (`summon-major-update.md`, `post-quantum-signature-aggregation-with-falcon-and-LaBRADOR.md`) had unquoted dates and were the visible offenders.
- The feed also contained an "Untitled Article" entry pointing at `/blog/README` (a 404).

## Changes
- [lib/rss.ts](lib/rss.ts): parser now accepts `Date` and `string`, and returns `null` on failure — articles with no/invalid date are skipped, not stamped with build time.
- [lib/rss.ts](lib/rss.ts): exclude `readme`, `_readme`, `_article-template` slugs at the collection step (matches the convention in [lib/content.ts](lib/content.ts)).
- Quoted the two unquoted dates in the affected article files to match every other article.